### PR TITLE
Change CryptoHelper to use Argon2id

### DIFF
--- a/Finances.Common/Finances.Common.csproj
+++ b/Finances.Common/Finances.Common.csproj
@@ -8,15 +8,10 @@
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
     <PackageReference Include="jose-jwt" Version="2.4.0" />
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.2.1" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnetcore.cryptography.keyderivation\2.2.0\lib\netcoreapp2.0\Microsoft.AspNetCore.Cryptography.KeyDerivation.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Finances.Core/Application/Authorization/Commands/SignIn/SignInHandler.cs
+++ b/Finances.Core/Application/Authorization/Commands/SignIn/SignInHandler.cs
@@ -41,7 +41,7 @@ namespace Finances.Core.Application.Authorization.Commands.SignIn
                     Message = "Login e/ou senha incorretos."
                 };
 
-            if (!cryptoHelper.Valid(request.Password, login.Password))
+            if (!cryptoHelper.IsValid(request.Password, login.Password))
                 return new JsonDefaultResponse
                 {
                     Success = false,


### PR DESCRIPTION
Changes the implementation of CryptoHelper to use Argon2id instead of the pbkdf2 from https://cmatskas.com/-net-password-hashing-using-pbkdf2/

Argument for using Argon2: https://security.stackexchange.com/questions/193351/in-2018-what-is-the-recommended-hash-to-store-passwords-bcrypt-scrypt-argon2